### PR TITLE
Add the missing memcmp function

### DIFF
--- a/src/badge_strings.c
+++ b/src/badge_strings.c
@@ -283,3 +283,10 @@ void *memmove(void *dst, void const *src, size_t len) {
     mem_copy(dst, src, len);
     return dst;
 }
+
+// Function call emitted by the compiler.
+int memcmp(void const *a, void const *b, size_t len) {
+	// This is not strictly correct according to the `memcmp` spec,
+	// but it will work for equality tests.
+	return !mem_equals(a, b, len);
+}

--- a/src/badge_strings.c
+++ b/src/badge_strings.c
@@ -286,7 +286,7 @@ void *memmove(void *dst, void const *src, size_t len) {
 
 // Function call emitted by the compiler.
 int memcmp(void const *a, void const *b, size_t len) {
-	// This is not strictly correct according to the `memcmp` spec,
-	// but it will work for equality tests.
-	return !mem_equals(a, b, len);
+    // This is not strictly correct according to the `memcmp` spec,
+    // but it will work for equality tests.
+    return !mem_equals(a, b, len);
 }


### PR DESCRIPTION
GCC will emit implicit calls to some string functions:
> GCC requires the freestanding environment provide memcpy, memmove, memset and memcmp.
The `memcmp` function was missing from this set.