### PR TITLE
Fix some bugs discovered during development of other things

### DIFF
--- a/port/esp32c6/src/rawprint.c
+++ b/port/esp32c6/src/rawprint.c
@@ -95,7 +95,7 @@ void rawprintuptime() {
         digits = 8;
 
     rawputc('[');
-    rawprint_substr(buf + 19 - digits, digits - 3);
+    rawprint_substr(buf + 20 - digits, digits - 3);
     rawputc('.');
     rawprint_substr(buf + 17, 3);
     rawputc(']');

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -393,9 +393,9 @@ void sched_request_switch_from_isr(void) {
 sched_thread_t *sched_create_userland_thread(
     badge_err_t *const            ec,
     process_t *const              process,
-    const sched_entry_point_t     entry_point,
+    sched_entry_point_t const     entry_point,
     void *const                   arg,
-    const sched_thread_priority_t priority
+    sched_thread_priority_t const priority
 ) {
     assert_dev_drop(process != NULL);
     assert_dev_drop(entry_point != NULL);
@@ -599,6 +599,7 @@ void sched_exit(uint32_t const exit_code) {
 
     current_thread->exit_code = exit_code;
     set_flag(current_thread->flags, THREAD_COMPLETED);
+    reset_flag(current_thread->flags, THREAD_RUNNING);
 
     leave_critical_section();
 


### PR DESCRIPTION
- The scheduler would re-enter a thread after `sched_exit` was called.
    - Fixed by resetting the `THREAD_RUNNING` flag in `sched_exit`
- The logger would divide the seconds part of the time by 10
    - Fixed by adding 1 to the offset in the `num_to_str` output buffer