### PR TITLE
Simple spinlock mutexes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,7 @@ add_executable(${target}
     ${CMAKE_CURRENT_LIST_DIR}/src/log.c
     ${CMAKE_CURRENT_LIST_DIR}/src/main.c
     ${CMAKE_CURRENT_LIST_DIR}/src/malloc.c
+    ${CMAKE_CURRENT_LIST_DIR}/src/mutex.c
     ${CMAKE_CURRENT_LIST_DIR}/src/num_to_str.c
     ${CMAKE_CURRENT_LIST_DIR}/src/scheduler.c
     ${CMAKE_CURRENT_LIST_DIR}/src/syscall.c

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -10,13 +10,11 @@
 
 typedef struct {
     // Magic value.
-    atomic_int  magic;
+    atomic_int magic;
     // Mutex allows sharing.
-    bool        is_shared;
-    // Exclusive mutex: Locked.
-    atomic_flag lock;
-    // Shared mutex: Share count.
-    atomic_int  shares;
+    bool       is_shared;
+    // Share count and/or is locked.
+    atomic_int shares;
 } mutex_t;
 
 // Initialise a mutex for unshared use.

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -1,0 +1,35 @@
+
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "badge_err.h"
+#include "time.h"
+
+#include <stdatomic.h>
+
+typedef struct {
+    // Mutex allows sharing.
+    bool is_shared;
+    // Exclusive mutex: Locked.
+    atomic_int lock;
+    // Shared mutex: Share count.
+    atomic_int shares;
+} mutex_t;
+
+// Initialise a mutex for unshared use.
+void mutex_init(badge_err_t *ec, mutex_t *mutex);
+// Initialise a mutex for shared use.
+void mutex_init_shared(badge_err_t *ec, mutex_t *mutex);
+// Try to acquire `mutex` within `max_wait_us` microseconds.
+// Returns true if the mutex was successully acquired.
+bool mutex_acquire(badge_err_t *ec, mutex_t *mutex, timestamp_us_t max_wait_us);
+// Release `mutex`, if it was initially acquired by this thread.
+// Returns true if the mutex was successfully released.
+bool mutex_release(badge_err_t *ec, mutex_t *mutex);
+// Try to acquire a share in `mutex` within `max_wait_us` microseconds.
+// Returns true if the share was successfully acquired.
+bool mutex_acquire_shared(badge_err_t *ec, mutex_t *mutex, timestamp_us_t max_wait_us);
+// Release `mutex`, if it was initially acquired by this thread.
+// Returns true if the mutex was successfully released.
+bool mutex_release_shared(badge_err_t *ec, mutex_t *mutex);

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -10,7 +10,7 @@
 
 typedef struct {
     // Magic value.
-    uint16_t    magic;
+    atomic_int  magic;
     // Mutex allows sharing.
     bool        is_shared;
     // Exclusive mutex: Locked.

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -8,6 +8,9 @@
 
 #include <stdatomic.h>
 
+// Magic value for the magic field.
+#define MUTEX_MAGIC (int)0xcafebabe
+
 typedef struct {
     // Magic value.
     atomic_int magic;
@@ -16,6 +19,9 @@ typedef struct {
     // Share count and/or is locked.
     atomic_int shares;
 } mutex_t;
+
+#define MUTEX_T_INIT        ((mutex_t){MUTEX_MAGIC, 0, 0})
+#define MUTEX_T_INIT_SHARED ((mutex_t){MUTEX_MAGIC, 1, 0})
 
 // Initialise a mutex for unshared use.
 void mutex_init(badge_err_t *ec, mutex_t *mutex);

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -9,6 +9,8 @@
 #include <stdatomic.h>
 
 typedef struct {
+    // Magic value.
+    uint16_t magic;
     // Mutex allows sharing.
     bool is_shared;
     // Exclusive mutex: Locked.
@@ -21,6 +23,8 @@ typedef struct {
 void mutex_init(badge_err_t *ec, mutex_t *mutex);
 // Initialise a mutex for shared use.
 void mutex_init_shared(badge_err_t *ec, mutex_t *mutex);
+// Clean up the mutex.
+void mutex_destroy(badge_err_t *ec, mutex_t *mutex);
 // Try to acquire `mutex` within `max_wait_us` microseconds.
 // Returns true if the mutex was successully acquired.
 bool mutex_acquire(badge_err_t *ec, mutex_t *mutex, timestamp_us_t max_wait_us);

--- a/include/mutex.h
+++ b/include/mutex.h
@@ -10,13 +10,13 @@
 
 typedef struct {
     // Magic value.
-    uint16_t magic;
+    uint16_t    magic;
     // Mutex allows sharing.
-    bool is_shared;
+    bool        is_shared;
     // Exclusive mutex: Locked.
-    atomic_int lock;
+    atomic_flag lock;
     // Shared mutex: Share count.
-    atomic_int shares;
+    atomic_int  shares;
 } mutex_t;
 
 // Initialise a mutex for unshared use.

--- a/src/main.c
+++ b/src/main.c
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: MIT
 
 #include "assertions.h"
-#include "attributes.h"
-#include "cpu/riscv_pmp.h"
 #include "gpio.h"
 #include "log.h"
 #include "malloc.h"
@@ -11,7 +9,6 @@
 #include "port/interrupt.h"
 #include "rawprint.h"
 #include "scheduler.h"
-#include "syscall.h"
 #include "time.h"
 
 #include <stdint.h>
@@ -19,37 +16,9 @@
 // Temporary kernel context until threading is implemented.
 static kernel_ctx_t kctx;
 
-static void         led_blink_loop(void *);
-static void         uart_print_loop(void *);
-
-struct led_config {
-    int      pin;
-    uint64_t off_time;
-    uint64_t on_time;
-};
-
-static struct led_config led_pins[3] = {
-    {.pin = 19, .off_time = 300000, .on_time = 200000},
-    {.pin = 20, .off_time = 250000, .on_time = 350000},
-    {.pin = 21, .off_time = 500000, .on_time = 400000},
-};
-static uint8_t led_blink_stack[3][512] ALIGNED_TO(STACK_ALIGNMENT);
-static uint8_t uart_print_stack[3][256] ALIGNED_TO(STACK_ALIGNMENT);
-
-
-uint32_t       userland_stack[1024];
-
-static void    userland_entry(void *ignored) {
-    asm(".option push\n"
-           ".option norelax\n"
-           ".global __global_pointer$\n"
-           ".global userland_stack\n"
-           "la gp, __global_pointer$\n"
-           "la sp, userland_stack+4096\n"
-           ".option pop");
-    logk(LOG_DEBUG, "This is a USER MESSAGE!");
-    while (1) syscall_thread_yield();
-}
+void                debug_func(void *);
+#define stack_size 1024
+static uint8_t stack0[stack_size] ALIGNED_TO(STACK_ALIGNMENT);
 
 // This is the entrypoint after the stack has been set up and the init functions
 // have been run. Main is not allowed to return, so declare it noreturn.
@@ -68,104 +37,37 @@ void main() {
     // called as early as possible.
     time_init();
 
+    // Set up memory allocator.
     kernel_heap_init();
 
-    // Test a log message.
-    logk(LOG_FATAL, "The ultimage log message test");
-    logk(LOG_ERROR, "The ultimage log message test");
-    logk(LOG_WARN, "The ultimage log message test");
-    logk(LOG_INFO, "The ultimage log message test");
-    logk(LOG_DEBUG, "The ultimage log message test");
-
-    // Test a GPIO.
-    io_mode(NULL, 22, IO_MODE_INPUT);
-    io_pull(NULL, 22, IO_PULL_UP);
-
-
-
+    // Set up multithreading.
     sched_init(&err);
     assert_always(badge_err_is_ok(&err));
 
-    for (size_t i = 0; i < 3; i++) {
-
-        sched_thread_t *const led_thread = sched_create_kernel_thread(
-            &err,
-            led_blink_loop,
-            &led_pins[i],
-            led_blink_stack[i],
-            sizeof led_blink_stack[i],
-            SCHED_PRIO_NORMAL
-        );
-        assert_always(badge_err_is_ok(&err));
-        assert_always(led_thread != NULL);
-
-        char thread_name[] = {'l', 'e', 'd', '-', '0' + i, 0};
-
-        sched_set_name(&err, led_thread, thread_name);
-        assert_always(badge_err_is_ok(&err));
-
-        sched_resume_thread(&err, led_thread);
-        assert_always(badge_err_is_ok(&err));
-    }
-
-    sched_thread_t *const print_thread = sched_create_kernel_thread(
-        &err,
-        uart_print_loop,
-        NULL,
-        uart_print_stack,
-        sizeof uart_print_stack,
-        SCHED_PRIO_NORMAL
-    );
+    // A debug thread.
+    sched_thread_t *const debug_thread_0 =
+        sched_create_kernel_thread(&err, debug_func, NULL, stack0, stack_size, SCHED_PRIO_NORMAL);
     assert_always(badge_err_is_ok(&err));
-    assert_always(print_thread != NULL);
-
-    sched_set_name(&err, print_thread, "print");
+    sched_set_name(&err, debug_thread_0, "debug0");
     assert_always(badge_err_is_ok(&err));
-
-    sched_resume_thread(&err, print_thread);
+    sched_resume_thread(&err, debug_thread_0);
     assert_always(badge_err_is_ok(&err));
-
 
     // Enter the scheduler
     sched_exec();
-
     __builtin_unreachable();
 }
 
-static void led_blink_loop(void *ptr) {
-    struct led_config *cfg = ptr;
-
-    logkf(LOG_INFO, "led thread %{d} (%{size;x})", cfg->pin, (size_t)cfg);
-
-    io_mode(NULL, cfg->pin, IO_MODE_OUTPUT);
-
-    int64_t next_blink = time_us();
+void debug_func(void *arg) {
+    (void)arg;
+    io_mode(NULL, 19, IO_MODE_OUTPUT);
+    timestamp_us_t t;
     while (1) {
-        io_write(NULL, cfg->pin, true);
-        next_blink += cfg->on_time;
-        while (time_us() < next_blink) {
-            sched_yield();
-        }
-
-        io_write(NULL, cfg->pin, false);
-        next_blink += cfg->off_time;
-        while (time_us() < next_blink) {
-            sched_yield();
-        }
-    }
-}
-
-static void uart_print_loop(void *) {
-
-    int loops = 0;
-
-    while (1) {
-        int64_t const now = time_us();
-
-
-        // Busy waiting loop to test preemptive multitasking.
-        while (time_us() < now + 700000)
-            ;
-        logkf(LOG_INFO, "timer loop %{d}", ++loops);
+        io_write(NULL, 19, true);
+        t = time_us() + 500000;
+        while (time_us() < t) sched_yield();
+        io_write(NULL, 19, false);
+        t = time_us() + 500000;
+        while (time_us() < t) sched_yield();
     }
 }

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -1,0 +1,117 @@
+
+// SPDX-License-Identifier: MIT
+
+#include "mutex.h"
+
+#include "scheduler.h"
+#include "time.h"
+
+// Await the value of an `atomic_int`.
+static bool await_atomic_int(atomic_int *var, timestamp_us_t timeout, int expected, int new_value, memory_order order) {
+    do {
+        int old_value = expected;
+        if (atomic_compare_exchange_weak_explicit(var, &old_value, new_value, order, memory_order_relaxed)) {
+            return true;
+        } else {
+            sched_yield();
+        }
+    } while (time_us() < timeout);
+    return false;
+}
+
+
+
+// Initialise a mutex for unshared use.
+void mutex_init(badge_err_t *ec, mutex_t *mutex) {
+    badge_err_set_ok(ec);
+    mutex->is_shared = false;
+    mutex->lock      = false;
+    mutex->shares    = 0;
+}
+
+// Initialise a mutex for shared use.
+void mutex_init_shared(badge_err_t *ec, mutex_t *mutex) {
+    badge_err_set_ok(ec);
+    mutex->is_shared = true;
+    mutex->lock      = false;
+    mutex->shares    = 0;
+}
+
+// Try to acquire `mutex` within `timeout` microseconds.
+// Returns true if the mutex was successully acquired.
+bool mutex_acquire(badge_err_t *ec, mutex_t *mutex, timestamp_us_t timeout) {
+    timeout += time_us();
+    // Take the lock.
+    if (!await_atomic_int(&mutex->lock, timeout, false, true, memory_order_acquire)) {
+        badge_err_set(ec, ELOC_UNKNOWN, ECAUSE_TIMEOUT);
+        return false;
+    }
+    // Await the shared portion to reach 0.
+    if (await_atomic_int(&mutex->shares, timeout, 0, 0, memory_order_acquire)) {
+        // If that succeeds, the mutex was acquired.
+        badge_err_set_ok(ec);
+        return true;
+    } else {
+        // If that fails, abort trying to lock.
+        atomic_store_explicit(&mutex->lock, false, memory_order_release);
+        badge_err_set(ec, ELOC_UNKNOWN, ECAUSE_TIMEOUT);
+        return false;
+    }
+}
+
+// Release `mutex`, if it was initially acquired by this thread.
+// Returns true if the mutex was successfully released.
+bool mutex_release(badge_err_t *ec, mutex_t *mutex) {
+    int the_true = true;
+    if (atomic_compare_exchange_strong_explicit(
+            &mutex->lock,
+            &the_true,
+            false,
+            memory_order_release,
+            memory_order_relaxed
+        )) {
+        badge_err_set_ok(ec);
+        return true;
+    } else {
+        badge_err_set(ec, ELOC_UNKNOWN, ECAUSE_ILLEGAL);
+        return false;
+    }
+}
+
+// Try to acquire a share in `mutex` within `timeout` microseconds.
+// Returns true if the share was successfully acquired.
+bool mutex_acquire_shared(badge_err_t *ec, mutex_t *mutex, timestamp_us_t timeout) {
+    if (!mutex->is_shared) {
+        badge_err_set(ec, ELOC_UNKNOWN, ECAUSE_ILLEGAL);
+        return false;
+    }
+    timeout += time_us();
+    // Take a share.
+    atomic_fetch_add_explicit(&mutex->shares, 1, memory_order_acquire);
+    // Await the lock to be released.
+    if (await_atomic_int(&mutex->lock, timeout, false, false, memory_order_acquire)) {
+        // If that succeeds, the mutex was successfully acquired.
+        badge_err_set_ok(ec);
+        return true;
+    } else {
+        // If that fails, abort trying to lock.
+        badge_err_set(ec, ELOC_UNKNOWN, ECAUSE_TIMEOUT);
+        atomic_fetch_sub_explicit(&mutex->shares, 1, memory_order_relaxed);
+        return false;
+    }
+}
+
+// Release `mutex`, if it was initially acquired by this thread.
+// Returns true if the mutex was successfully released.
+bool mutex_release_shared(badge_err_t *ec, mutex_t *mutex) {
+    int old = atomic_fetch_sub_explicit(&mutex->shares, 1, memory_order_release);
+    if (old <= 0) {
+        // Prevent the counter from going below 0.
+        badge_err_set(ec, ELOC_UNKNOWN, ECAUSE_ILLEGAL);
+        atomic_fetch_add_explicit(&mutex->shares, 1, memory_order_relaxed);
+        return false;
+    } else {
+        // Successful release.
+        return true;
+    }
+}

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -6,8 +6,6 @@
 #include "scheduler.h"
 #include "time.h"
 
-// Magic value for the magic field.
-#define MUTEX_MAGIC     (int)0xcafebabe
 // Magic value for exclusive locking.
 #define EXCLUSIVE_MAGIC ((int)__INT_MAX__ / 4)
 

--- a/src/mutex.c
+++ b/src/mutex.c
@@ -6,6 +6,10 @@
 #include "scheduler.h"
 #include "time.h"
 
+#define MUTEX_MAGIC 0xfeca
+
+
+
 // Await the value of an `atomic_int`.
 static bool await_atomic_int(atomic_int *var, timestamp_us_t timeout, int expected, int new_value, memory_order order) {
     do {
@@ -23,23 +27,46 @@ static bool await_atomic_int(atomic_int *var, timestamp_us_t timeout, int expect
 
 // Initialise a mutex for unshared use.
 void mutex_init(badge_err_t *ec, mutex_t *mutex) {
+    uint16_t magic = atomic_load_explicit(&mutex->magic, memory_order_acquire);
+    if (magic == MUTEX_MAGIC) {
+        badge_err_set(ec, ELOC_UNKNOWN, ECAUSE_INUSE);
+    }
+    atomic_store_explicit(&mutex->magic, MUTEX_MAGIC, memory_order_relaxed);
+    atomic_store_explicit(&mutex->is_shared, false, memory_order_relaxed);
+    atomic_store_explicit(&mutex->lock, 0, memory_order_relaxed);
+    atomic_store_explicit(&mutex->shares, 0, memory_order_release);
     badge_err_set_ok(ec);
-    mutex->is_shared = false;
-    mutex->lock      = false;
-    mutex->shares    = 0;
 }
 
 // Initialise a mutex for shared use.
 void mutex_init_shared(badge_err_t *ec, mutex_t *mutex) {
+    uint16_t magic = atomic_load_explicit(&mutex->magic, memory_order_acquire);
+    if (magic == MUTEX_MAGIC) {
+        badge_err_set(ec, ELOC_UNKNOWN, ECAUSE_INUSE);
+    }
+    atomic_store_explicit(&mutex->magic, MUTEX_MAGIC, memory_order_relaxed);
+    atomic_store_explicit(&mutex->is_shared, true, memory_order_relaxed);
+    atomic_store_explicit(&mutex->lock, 0, memory_order_relaxed);
+    atomic_store_explicit(&mutex->shares, 0, memory_order_release);
     badge_err_set_ok(ec);
-    mutex->is_shared = true;
-    mutex->lock      = false;
-    mutex->shares    = 0;
+}
+
+// Clean up the mutex.
+void mutex_destroy(badge_err_t *ec, mutex_t *mutex) {
+    uint16_t magic = atomic_load_explicit(&mutex->magic, memory_order_acquire);
+    if (magic != MUTEX_MAGIC) {
+        badge_err_set(ec, ELOC_UNKNOWN, ECAUSE_ILLEGAL);
+    }
+    atomic_store_explicit(&mutex->magic, 0, memory_order_release);
 }
 
 // Try to acquire `mutex` within `timeout` microseconds.
 // Returns true if the mutex was successully acquired.
 bool mutex_acquire(badge_err_t *ec, mutex_t *mutex, timestamp_us_t timeout) {
+    uint16_t magic = atomic_load_explicit(&mutex->magic, memory_order_acquire);
+    if (magic != MUTEX_MAGIC) {
+        badge_err_set(ec, ELOC_UNKNOWN, ECAUSE_ILLEGAL);
+    }
     timeout += time_us();
     // Take the lock.
     if (!await_atomic_int(&mutex->lock, timeout, false, true, memory_order_acquire)) {
@@ -62,6 +89,10 @@ bool mutex_acquire(badge_err_t *ec, mutex_t *mutex, timestamp_us_t timeout) {
 // Release `mutex`, if it was initially acquired by this thread.
 // Returns true if the mutex was successfully released.
 bool mutex_release(badge_err_t *ec, mutex_t *mutex) {
+    uint16_t magic = atomic_load_explicit(&mutex->magic, memory_order_acquire);
+    if (magic != MUTEX_MAGIC) {
+        badge_err_set(ec, ELOC_UNKNOWN, ECAUSE_ILLEGAL);
+    }
     int the_true = true;
     if (atomic_compare_exchange_strong_explicit(
             &mutex->lock,
@@ -81,6 +112,10 @@ bool mutex_release(badge_err_t *ec, mutex_t *mutex) {
 // Try to acquire a share in `mutex` within `timeout` microseconds.
 // Returns true if the share was successfully acquired.
 bool mutex_acquire_shared(badge_err_t *ec, mutex_t *mutex, timestamp_us_t timeout) {
+    uint16_t magic = atomic_load_explicit(&mutex->magic, memory_order_acquire);
+    if (magic != MUTEX_MAGIC) {
+        badge_err_set(ec, ELOC_UNKNOWN, ECAUSE_ILLEGAL);
+    }
     if (!mutex->is_shared) {
         badge_err_set(ec, ELOC_UNKNOWN, ECAUSE_ILLEGAL);
         return false;
@@ -104,6 +139,10 @@ bool mutex_acquire_shared(badge_err_t *ec, mutex_t *mutex, timestamp_us_t timeou
 // Release `mutex`, if it was initially acquired by this thread.
 // Returns true if the mutex was successfully released.
 bool mutex_release_shared(badge_err_t *ec, mutex_t *mutex) {
+    uint16_t magic = atomic_load_explicit(&mutex->magic, memory_order_acquire);
+    if (magic != MUTEX_MAGIC) {
+        badge_err_set(ec, ELOC_UNKNOWN, ECAUSE_ILLEGAL);
+    }
     int old = atomic_fetch_sub_explicit(&mutex->shares, 1, memory_order_release);
     if (old <= 0) {
         // Prevent the counter from going below 0.


### PR DESCRIPTION
A simple, tested mutex implementation based on spinlocks.
- No deadlock detection
- No thread ownership
- Read-write (AKA shareable) mutexe support
- Implicit `sched_yield` until mutex is acquired
- Fully lock-free release