### PR TITLE
Support for not using timeouts on mutexes.

### DIFF
--- a/include/mutex.h
+++ b/include/mutex.h
@@ -30,12 +30,14 @@ void mutex_init_shared(badge_err_t *ec, mutex_t *mutex);
 // Clean up the mutex.
 void mutex_destroy(badge_err_t *ec, mutex_t *mutex);
 // Try to acquire `mutex` within `max_wait_us` microseconds.
+// If `max_wait_us` is too long or negative, do not use the timeout.
 // Returns true if the mutex was successully acquired.
 bool mutex_acquire(badge_err_t *ec, mutex_t *mutex, timestamp_us_t max_wait_us);
 // Release `mutex`, if it was initially acquired by this thread.
 // Returns true if the mutex was successfully released.
 bool mutex_release(badge_err_t *ec, mutex_t *mutex);
 // Try to acquire a share in `mutex` within `max_wait_us` microseconds.
+// If `max_wait_us` is too long or negative, do not use the timeout.
 // Returns true if the share was successfully acquired.
 bool mutex_acquire_shared(badge_err_t *ec, mutex_t *mutex, timestamp_us_t max_wait_us);
 // Release `mutex`, if it was initially acquired by this thread.

--- a/include/time.h
+++ b/include/time.h
@@ -9,6 +9,13 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#define FREQUENCY_HZ_MIN INT32_MIN
+#define FREQUENCY_HZ_MAX INT32_MAX
+#define TIMESTAMP_US_MIN INT64_MIN
+#define TIMESTAMP_US_MAX INT64_MAX
+#define TIMER_VALUE_MIN  INT64_MIN
+#define TIMER_VALUE_MAX  INT64_MAX
+
 typedef int32_t frequency_hz_t;
 typedef int64_t timestamp_us_t;
 typedef int64_t timer_value_t;


### PR DESCRIPTION
If the timeout value causes an integer overflow, or is a negative value, no timeout is used on mutex acquire.