### PR TITLE
Fix printing characters to USB ACM device

### DIFF
--- a/port/esp32c6/src/rawprint.c
+++ b/port/esp32c6/src/rawprint.c
@@ -57,6 +57,8 @@ void rawprint(char const *msg) {
 
 // Simple printer.
 void rawputc(char msg) {
+    while (!(READ_REG(USB_JTAG_BASE + 4) & 2))
+        ;
     WRITE_REG(USB_JTAG_BASE, msg);
     WRITE_REG(UART0_BASE, msg);
 }


### PR DESCRIPTION
When printing to the C6's internal USB ACM device, some characters were skipped because the code did not check whether the peripheral had space in the TX buffer.