### PR TITLE
Memory protection stub function

### DIFF
--- a/kernel/include/memprotect.h
+++ b/kernel/include/memprotect.h
@@ -3,14 +3,28 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
+
+#define MEMPROTECT_FLAG_R      0x00000001
+#define MEMPROTECT_FLAG_W      0x00000002
+#define MEMPROTECT_FLAG_X      0x00000004
+#define MEMPROTECT_FLAG_KERNEL 0x80000000
+
+// #include <port/memprotect.h>
+// #include <process/process.h>
+typedef struct {
+} mpu_ctx_t;
+
+
+
+// MPU context for kernel threads not associated to processes.
+extern mpu_ctx_t kernel_mpu_ctx;
 
 // Initialise memory protection driver.
 void memprotect_init();
-
-// Set the range of external RAM assigned to userland.
-void memprotect_set_user_extram(size_t base, size_t top);
-// Set the range of SRAM assigned to userland.
-void memprotect_set_user_sram(size_t base, size_t top);
-// Set the range of flash assigned to userland.
-void memprotect_set_user_flash(size_t base, size_t top);
+// Add a memory protection region.
+bool memprotect(mpu_ctx_t *ctx, size_t vaddr, size_t paddr, size_t length, uint32_t flags);
+// Commit pending memory protections, if any.
+void memprotect_commit(mpu_ctx_t *ctx);

--- a/kernel/port/esp32c6/include/port/hardware_allocation.h
+++ b/kernel/port/esp32c6/include/port/hardware_allocation.h
@@ -81,6 +81,10 @@
 // TOR PMP entry for SRAM assigned to userland.
 #define PMP_ENTRY_USER_FLASH_TOR     9
 
+// Kernel supports virtual memory.
+#define MEMMAP_VMEM             0
+// Page size for memory protections.
+#define MEMMAP_PAGE_SIZE        4096
 // Maximum number of mapped regions per process.
 #define PROC_MEMMAP_MAX_REGIONS 8
 // Lowest numbered PMP to use for process memory maps, must be a multiple of 4.

--- a/kernel/port/esp32c6/include/port/memprotect.h
+++ b/kernel/port/esp32c6/include/port/memprotect.h
@@ -1,0 +1,8 @@
+
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "cpu/riscv_pmp.h"
+
+typedef riscv_pmp_ctx_t mpu_ctx_t;

--- a/kernel/port/esp32c6/src/memprotect.c
+++ b/kernel/port/esp32c6/src/memprotect.c
@@ -3,6 +3,7 @@
 
 #include "memprotect.h"
 
+#include "assertions.h"
 #include "cpu/riscv_pmp.h"
 #include "port/hardware_allocation.h"
 #include "port/interrupt.h"
@@ -84,80 +85,23 @@ void memprotect_init() {
     );
 }
 
-// Set the range of external RAM currently assigned to userland.
-void memprotect_set_user_extram(size_t base, size_t top) {
-    bool mie = interrupt_disable();
 
-    // Disable existing entry.
-    riscv_pmpcfg_clear(PMP_ENTRY_USER_EXTRAM_TOR);
-    // Write new addresses.
-    riscv_pmpaddr_write(PMP_ENTRY_USER_EXTRAM_BASE, base);
-    riscv_pmpaddr_write(PMP_ENTRY_USER_EXTRAM_TOR, top);
-    // Set PMP region type.
-    riscv_pmpcfg_set(
-        PMP_ENTRY_USER_EXTRAM_TOR,
-        ((riscv_pmpcfg_t){
-            .read            = true,
-            .write           = true,
-            .exec            = true,
-            .addr_match_mode = RISCV_PMPCFG_TOR,
-            ._reserved       = 0,
-            .lock            = false,
-        })
-    );
 
-    if (mie)
-        interrupt_enable();
+// Add a memory protection region.
+bool memprotect(mpu_ctx_t *ctx, size_t vaddr, size_t paddr, size_t length, uint32_t flags) {
+    // return vaddr == paddr && riscv_pmp_memprotect(ctx, vaddr, length, flags);
+    assert_dev_drop(vaddr == paddr);
+    (void)ctx;
+    (void)vaddr;
+    (void)paddr;
+    (void)length;
+    (void)flags;
+    return true;
 }
 
-// Set the range of SRAM currently assigned to userland.
-void memprotect_set_user_sram(size_t base, size_t top) {
-    bool mie = interrupt_disable();
 
-    // Disable existing entry.
-    riscv_pmpcfg_clear(PMP_ENTRY_USER_SRAM_TOR);
-    // Write new addresses.
-    riscv_pmpaddr_write(PMP_ENTRY_USER_SRAM_BASE, base);
-    riscv_pmpaddr_write(PMP_ENTRY_USER_SRAM_TOR, top);
-    // Set PMP region type.
-    riscv_pmpcfg_set(
-        PMP_ENTRY_USER_SRAM_TOR,
-        ((riscv_pmpcfg_t){
-            .read            = true,
-            .write           = true,
-            .exec            = true,
-            .addr_match_mode = RISCV_PMPCFG_TOR,
-            ._reserved       = 0,
-            .lock            = false,
-        })
-    );
 
-    if (mie)
-        interrupt_enable();
-}
-
-// Set the range of flash currently assigned to userland.
-void memprotect_set_user_flash(size_t base, size_t top) {
-    bool mie = interrupt_disable();
-
-    // Disable existing entry.
-    riscv_pmpcfg_clear(PMP_ENTRY_USER_FLASH_TOR);
-    // Write new addresses.
-    riscv_pmpaddr_write(PMP_ENTRY_USER_FLASH_BASE, base);
-    riscv_pmpaddr_write(PMP_ENTRY_USER_FLASH_TOR, top);
-    // Set PMP region type.
-    riscv_pmpcfg_set(
-        PMP_ENTRY_USER_FLASH_TOR,
-        ((riscv_pmpcfg_t){
-            .read            = true,
-            .write           = true,
-            .exec            = true,
-            .addr_match_mode = RISCV_PMPCFG_TOR,
-            ._reserved       = 0,
-            .lock            = false,
-        })
-    );
-
-    if (mie)
-        interrupt_enable();
+// Commit pending memory protections, if any.
+void memprotect_commit(mpu_ctx_t *ctx) {
+    (void)ctx;
 }


### PR DESCRIPTION
This adds the stub functions `memprotect` and `memprotect_commit` in `memprotect.h`, for later use by the page allocator.