### PR TITLE
Add shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,53 @@
+let
+  nixpkgs_rev = "f4429fde23e1fb20ee27f264e74c28c619d2cebb";
+in
+
+{ pkgs ? import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/${nixpkgs_rev}.tar.gz") { }
+}:
+
+with pkgs;
+let
+  riscv32-unknown-linux-gnu = stdenv.mkDerivation rec {
+    name = "riscv32-unknown-linux-gnu";
+    version = "13.2.0";
+
+    release = "2024.03.01";
+    ubuntu_version = "22.04";
+
+    src = (builtins.fetchTarball "https://github.com/riscv-collab/riscv-gnu-toolchain/releases/download/${release}/riscv32-glibc-ubuntu-${ubuntu_version}-gcc-nightly-${release}-nightly.tar.gz");
+
+    buildInputs = [
+      autoPatchelfHook
+
+      zlib
+      glib
+      gmp
+      zstd
+      mpfr
+      libmpc
+      lzma
+      expat
+      python310
+      ncurses
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out
+
+      cp -r bin $out
+      cp -r lib $out
+      cp -r libexec $out
+      cp -r riscv32-unknown-linux-gnu $out
+
+      runHook postInstall
+    '';
+  };
+in
+mkShell {
+  buildInputs = [
+    riscv32-unknown-linux-gnu
+    cmake
+  ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -49,5 +49,6 @@ mkShell {
   buildInputs = [
     riscv32-unknown-linux-gnu
     cmake
+    esptool
   ];
 }

--- a/shell.nix
+++ b/shell.nix
@@ -50,5 +50,6 @@ mkShell {
     riscv32-unknown-linux-gnu
     cmake
     esptool
+    picocom
   ];
 }


### PR DESCRIPTION
Add Nix expression that provides shell with `riscv32-unknown-linux-gnu` toolchain from [riscv32-glibc-ubuntu-22.04-gcc-nightly-2024.03.01](https://github.com/riscv-collab/riscv-gnu-toolchain/releases/tag/2024.03.01). Users if Nix(OS) simply can run `nix-shell` in the root of this repo.